### PR TITLE
Add non-root user to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,17 @@ WORKDIR /app
 
 RUN apt-get update \
     && apt-get dist-upgrade -y --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --shell /bin/bash appuser
 
 COPY . /app
 
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -e .
+    && pip install --no-cache-dir -e . \
+    && chown -R appuser:appuser /app
 
 ENV PYTHONUNBUFFERED=1
+
+USER appuser
 
 CMD ["uvicorn", "api.investment.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- create an `appuser` user inside the container
- switch ownership of `/app` to the new user and run as it

## Testing
- `docker-compose build` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_b_6869be1724a48325984d53211e5f0c12