### PR TITLE
Implement inventory mapping loaders

### DIFF
--- a/inventory/core/mapping.py
+++ b/inventory/core/mapping.py
@@ -46,21 +46,7 @@ class BaseMappingEntity(BaseModel):
 
         lds: LocalDataSource = self._local_datasource()
 
-        load_methods = {
-            "household": lds.load_house,
-            "photo": lds.load_photo,
-            "room": lds.load_room,
-            "book": lds.load_book,
-            "decor": lds.load_decor,
-            "item": lds.load_item,
-        }
-
-        init_method = load_methods.get(self.entity_type)
-
-        if init_method is None:
-            raise KeyError(f"Entity type '{self.entity_type}' has not been configured.")
-
-        di: dict[str, Any] = init_method(self)
+        di: dict[str, Any] = lds.load_entity(self)
         for key, el in di.items():
             if hasattr(self, key):
                 setattr(self, key, el)

--- a/inventory/datasource/base.py
+++ b/inventory/datasource/base.py
@@ -1,12 +1,12 @@
 """Base class definitions for inventory data sources."""
 
-from typing import ClassVar, Any
 import datetime
 from pathlib import Path
-
-from ..config import BASE_PATH
+from typing import ClassVar, Any
 
 from pydantic import BaseModel, ConfigDict
+
+from ..config import BASE_PATH
 
 class BaseDataSource(BaseModel):
     """Minimal base class for inventory data sources."""

--- a/inventory/datasource/base.py
+++ b/inventory/datasource/base.py
@@ -1,6 +1,10 @@
 """Base class definitions for inventory data sources."""
 
 from typing import ClassVar, Any
+import datetime
+from pathlib import Path
+
+from ..config import BASE_PATH
 
 from pydantic import BaseModel, ConfigDict
 
@@ -16,6 +20,32 @@ class BaseDataSource(BaseModel):
             super().__setattr__(name, value)
         except ValueError:
             object.__setattr__(self, name, value)
+
+    @staticmethod
+    def _get_file_names_in_path(path: str) -> dict[str, datetime.datetime]:
+        """Return mapping of file names to last modified datetime."""
+        folder = Path(path)
+
+        di: dict[str, datetime.datetime] = {}
+        if not folder.exists():
+            return di
+        if not folder.is_dir():
+            raise NotADirectoryError(f"{path} is not a directory")
+        for file_path in folder.iterdir():
+            if file_path.is_file() and not file_path.name.startswith('.'):
+                file_stem = file_path.stem
+                last_modified_timestamp = file_path.stat().st_mtime
+                last_modified_datetime = datetime.datetime.fromtimestamp(
+                    last_modified_timestamp
+                )
+                di[file_stem] = last_modified_datetime
+
+        return di
+
+    @staticmethod
+    def mapping_path(name: str) -> str:
+        """Return the CSV path for a given mapping name."""
+        return f"{BASE_PATH}/{name}_mapping.csv"
 
 __all__ = [
     "BaseDataSource",

--- a/inventory/datasource/local.py
+++ b/inventory/datasource/local.py
@@ -4,35 +4,51 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, TYPE_CHECKING
 
+import pandas as pd
+
 from .base import BaseDataSource
+from investment.utils.exceptions import SecurityMappingError
 
 if TYPE_CHECKING:
     from ..core import (
         House, Photo, Room, Book, Decor, Music
     )
+    from ..core.item import BaseItem
+    from ..core.mapping import BaseMappingEntity
 
 class LocalDataSource(BaseDataSource):
     """Data source that reads from local CSV files."""
 
     name: ClassVar[str] = "local"
 
-    def load_house(self, house: "House") -> dict[str, Any]:
-        pass
+    def get_mapping(self, name: str) -> pd.DataFrame:
+        """Load a mapping table from disk."""
+        return pd.read_csv(self.mapping_path(name))
 
-    def load_photo(self, photo: "Photo") -> dict[str, Any]:
-        pass
+    def write_mapping(self, name: str, df: pd.DataFrame) -> None:
+        """Persist a mapping table to disk."""
+        df.to_csv(self.mapping_path(name), index=False)
 
-    def load_room(self, room: "Room") -> dict[str, Any]:
-        pass
+    @staticmethod
+    def _load(df: pd.DataFrame, entity: "BaseMappingEntity" | None = None) -> dict[str, Any]:
+        """Convert a single CSV row to a dictionary."""
+        if len(df) > 1:
+            raise SecurityMappingError(
+                f"Duplicate {entity.entity_type} for code '{entity.code}'" if entity else "Duplicate data."
+            )
+        if len(df) == 0:
+            raise SecurityMappingError(
+                f"No {entity.entity_type} for code '{entity.code}'" if entity else "Missing data."
+            )
 
-    def load_book(self, book_item: "Book") -> dict[str, Any]:
-        pass
+        di = df.iloc[0].to_dict()
+        return {k: v for k, v in di.items() if not pd.isna(v)}
 
-    def load_decor(self, deco_item: "Decor") -> dict[str, Any]:
-        pass
-
-    def load_music(self, music_item: "Music") -> dict[str, Any]:
-        pass
+    def load_entity(self, entity: "BaseMappingEntity") -> dict[str, Any]:
+        """Return mapping data for the given entity."""
+        df = self.get_mapping(entity.entity_type)
+        row = df.loc[df.code == entity.code]
+        return self._load(df=row, entity=entity)
 
 __all__ = [
     "LocalDataSource",

--- a/inventory/datasource/local.py
+++ b/inventory/datasource/local.py
@@ -10,10 +10,6 @@ from .base import BaseDataSource
 from ..utils.exceptions import SecurityMappingError
 
 if TYPE_CHECKING:
-    from ..core import (
-        House, Photo, Room, Book, Decor, Music
-    )
-    from ..core.item import BaseItem
     from ..core.mapping import BaseMappingEntity
 
 class LocalDataSource(BaseDataSource):
@@ -34,11 +30,15 @@ class LocalDataSource(BaseDataSource):
         """Convert a single CSV row to a dictionary."""
         if len(df) > 1:
             raise SecurityMappingError(
-                f"Duplicate {entity.entity_type} for code '{entity.code}'" if entity else "Duplicate data."
+                f"Duplicate {entity.entity_type} for code '{entity.code}'"
+                if entity
+                else "Duplicate data."
             )
         if len(df) == 0:
             raise SecurityMappingError(
-                f"No {entity.entity_type} for code '{entity.code}'" if entity else "Missing data."
+                f"No {entity.entity_type} for code '{entity.code}'"
+                if entity
+                else "Missing data."
             )
 
         di = df.iloc[0].to_dict()

--- a/inventory/datasource/local.py
+++ b/inventory/datasource/local.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar, TYPE_CHECKING
 import pandas as pd
 
 from .base import BaseDataSource
-from investment.utils.exceptions import SecurityMappingError
+from ..utils.exceptions import SecurityMappingError
 
 if TYPE_CHECKING:
     from ..core import (

--- a/inventory/utils/__init__.py
+++ b/inventory/utils/__init__.py
@@ -1,7 +1,9 @@
 """Utility helpers for the inventory module."""
 
 from .consts import DEFAULT_CURRENCY
+from .exceptions import SecurityMappingError
 
 __all__ = [
     "DEFAULT_CURRENCY",
+    "SecurityMappingError",
 ]

--- a/inventory/utils/exceptions.py
+++ b/inventory/utils/exceptions.py
@@ -2,4 +2,3 @@
 
 class SecurityMappingError(Exception):
     """Raised for issues within the mapping files."""
-

--- a/inventory/utils/exceptions.py
+++ b/inventory/utils/exceptions.py
@@ -1,0 +1,5 @@
+"""Custom exception classes for the inventory package."""
+
+class SecurityMappingError(Exception):
+    """Raised for issues within the mapping files."""
+


### PR DESCRIPTION
## Summary
- add `mapping_path` helper in inventory datasource base
- refactor local datasource to use generic mapping helpers
- simplify `BaseMappingEntity` initialisation
- remove dashed separator comments

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_68703dd05ac083258b75cbc2c1ce5534