### PR TITLE
Add type hints

### DIFF
--- a/investment/analytics/metrics.py
+++ b/investment/analytics/metrics.py
@@ -9,17 +9,14 @@ derive cumulative and annualised performance statistics, drawdown measures and
 risk‑adjusted ratios such as Sharpe and Sortino.
 """
 
-from typing import Callable, Any
+from typing import Any, Callable, Self
 
 import numpy as np
 import pandas as pd
 
+from ..utils.consts import DEFAULT_METRIC_WIN_SIZE, DEFAULT_RISK_FREE_RATE, TRADING_DAYS
 from .base import BaseAnalytics
-from ..utils.consts import (
-    TRADING_DAYS,
-    DEFAULT_METRIC_WIN_SIZE,
-    DEFAULT_RISK_FREE_RATE,
-)
+
 
 class PerformanceMetrics(BaseAnalytics):
     """Collection of common portfolio performance calculations.
@@ -80,7 +77,7 @@ class PerformanceMetrics(BaseAnalytics):
 
     @classmethod
     def cumulative_return(
-        cls,
+        cls: type[Self],
         df: pd.DataFrame,
         metric_win_size: int = DEFAULT_METRIC_WIN_SIZE,
     ) -> pd.DataFrame:
@@ -107,7 +104,7 @@ class PerformanceMetrics(BaseAnalytics):
 
     @classmethod
     def annualised_return(
-        cls,
+        cls: type[Self],
         df: pd.DataFrame,
         metric_win_size: int = DEFAULT_METRIC_WIN_SIZE,
         periods_per_year: int = TRADING_DAYS,
@@ -148,7 +145,7 @@ class PerformanceMetrics(BaseAnalytics):
         )
 
     @classmethod
-    def drawdown_series(cls, df: pd.DataFrame) -> pd.DataFrame:
+    def drawdown_series(cls: type[Self], df: pd.DataFrame) -> pd.DataFrame:
         """Series of drawdowns as percentages from peak equity.
 
         Parameters
@@ -170,7 +167,7 @@ class PerformanceMetrics(BaseAnalytics):
 
     @classmethod
     def max_drawdown(
-        cls,
+        cls: type[Self],
         df: pd.DataFrame,
         metric_win_size: int = DEFAULT_METRIC_WIN_SIZE,
     ) -> pd.DataFrame:
@@ -187,6 +184,7 @@ class PerformanceMetrics(BaseAnalytics):
             ``as_of_date`` and ``value`` of the maximum drawdown for each
             rolling window.
         """
+
         def func(x: pd.Series) -> float:
             cum_returns = (1 + x).cumprod()
             running_max = cum_returns.cummax()
@@ -199,7 +197,7 @@ class PerformanceMetrics(BaseAnalytics):
 
     @classmethod
     def sharpe_ratio(
-        cls,
+        cls: type[Self],
         df: pd.DataFrame,
         metric_win_size: int = DEFAULT_METRIC_WIN_SIZE,
         risk_free_rate: float = DEFAULT_RISK_FREE_RATE,
@@ -241,7 +239,7 @@ class PerformanceMetrics(BaseAnalytics):
 
     @classmethod
     def sortino_ratio(
-        cls,
+        cls: type[Self],
         df: pd.DataFrame,
         metric_win_size: int = DEFAULT_METRIC_WIN_SIZE,
         risk_free_rate: float = DEFAULT_RISK_FREE_RATE,
@@ -283,7 +281,7 @@ class PerformanceMetrics(BaseAnalytics):
 
     @classmethod
     def downside_volatility(
-        cls,
+        cls: type[Self],
         df: pd.DataFrame,
         metric_win_size: int = DEFAULT_METRIC_WIN_SIZE,
         periods_per_year: int = TRADING_DAYS,
@@ -321,7 +319,7 @@ class PerformanceMetrics(BaseAnalytics):
 
     @classmethod
     def calmar_ratio(
-        cls,
+        cls: type[Self],
         df: pd.DataFrame,
         metric_win_size: int = DEFAULT_METRIC_WIN_SIZE,
         periods_per_year: int = TRADING_DAYS,
@@ -359,7 +357,7 @@ class PerformanceMetrics(BaseAnalytics):
 
     @classmethod
     def omega_ratio(
-        cls,
+        cls: type[Self],
         df: pd.DataFrame,
         metric_win_size: int = DEFAULT_METRIC_WIN_SIZE,
         target_return: float = DEFAULT_RISK_FREE_RATE,
@@ -403,7 +401,7 @@ class PerformanceMetrics(BaseAnalytics):
 
     @classmethod
     def hit_ratio(
-        cls,
+        cls: type[Self],
         df: pd.DataFrame,
         metric_win_size: int = DEFAULT_METRIC_WIN_SIZE,
     ) -> pd.DataFrame:
@@ -427,6 +425,7 @@ class PerformanceMetrics(BaseAnalytics):
 
         result = cls._apply_window(returns, func, metric_win_size)
         return cls._to_dataframe(result, "hit_ratio", metric_win_size)
+
 
 __all__ = [
     "PerformanceMetrics",

--- a/investment/analytics/metrics.py
+++ b/investment/analytics/metrics.py
@@ -14,8 +14,8 @@ from typing import Any, Callable, Self
 import numpy as np
 import pandas as pd
 
-from ..utils.consts import DEFAULT_METRIC_WIN_SIZE, DEFAULT_RISK_FREE_RATE, TRADING_DAYS
 from .base import BaseAnalytics
+from ..utils.consts import DEFAULT_METRIC_WIN_SIZE, DEFAULT_RISK_FREE_RATE, TRADING_DAYS
 
 
 class PerformanceMetrics(BaseAnalytics):

--- a/investment/analytics/var.py
+++ b/investment/analytics/var.py
@@ -11,8 +11,8 @@ from typing import Callable, Self
 
 import pandas as pd
 
-from ..utils.consts import DEFAULT_CONFIDENCE_LEVEL, DEFAULT_VAR_WIN_SIZE
 from .base import BaseAnalytics
+from ..utils.consts import DEFAULT_CONFIDENCE_LEVEL, DEFAULT_VAR_WIN_SIZE
 
 
 class VaRCalculator(BaseAnalytics):

--- a/investment/analytics/var.py
+++ b/investment/analytics/var.py
@@ -7,12 +7,13 @@ and converted to simple returns.
 """
 
 from statistics import NormalDist
-from typing import Callable
+from typing import Callable, Self
 
 import pandas as pd
 
-from .base import BaseAnalytics
 from ..utils.consts import DEFAULT_CONFIDENCE_LEVEL, DEFAULT_VAR_WIN_SIZE
+from .base import BaseAnalytics
+
 
 class VaRCalculator(BaseAnalytics):
     """Value-at-Risk related calculations."""
@@ -57,7 +58,7 @@ class VaRCalculator(BaseAnalytics):
 
     @classmethod
     def historical_var(
-        cls,
+        cls: type[Self],
         df: pd.DataFrame,
         var_win_size: int = DEFAULT_VAR_WIN_SIZE,
         confidence_level: float = DEFAULT_CONFIDENCE_LEVEL,
@@ -77,7 +78,7 @@ class VaRCalculator(BaseAnalytics):
 
     @classmethod
     def parametric_var(
-        cls,
+        cls: type[Self],
         df: pd.DataFrame,
         var_win_size: int = DEFAULT_VAR_WIN_SIZE,
         confidence_level: float = DEFAULT_CONFIDENCE_LEVEL,
@@ -99,7 +100,7 @@ class VaRCalculator(BaseAnalytics):
 
     @classmethod
     def conditional_var(
-        cls,
+        cls: type[Self],
         df: pd.DataFrame,
         var_win_size: int = DEFAULT_VAR_WIN_SIZE,
         confidence_level: float = DEFAULT_CONFIDENCE_LEVEL,
@@ -119,6 +120,7 @@ class VaRCalculator(BaseAnalytics):
 
         result = cls._apply_window(returns, func, var_win_size)
         return cls._to_dataframe(result, "conditional", var_win_size, confidence_level)
+
 
 __all__ = [
     "VaRCalculator",

--- a/investment/config.py
+++ b/investment/config.py
@@ -7,31 +7,37 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # api keys
-TWELVE_DATA_API_KEY = os.getenv("TWELVE_DATA_API_KEY")
-ALPHA_VANTAGE_API_KEY = os.getenv("ALPHA_VANTAGE_API_KEY")
-OPEN_FIGI_API_KEY = os.getenv("OPEN_FIGI_API_KEY")
-QUANDL_API_KEY = os.getenv("QUANDL_API_KEY")
+TWELVE_DATA_API_KEY: str | None = os.getenv("TWELVE_DATA_API_KEY")
+ALPHA_VANTAGE_API_KEY: str | None = os.getenv("ALPHA_VANTAGE_API_KEY")
+OPEN_FIGI_API_KEY: str | None = os.getenv("OPEN_FIGI_API_KEY")
+QUANDL_API_KEY: str | None = os.getenv("QUANDL_API_KEY")
 # Optional API keys used to secure FastAPI endpoints
 # If any of these are ``None`` the corresponding app will reject all requests.
-FASTAPI_INVESTMENT_API_KEY = os.getenv("FASTAPI_INVESTMENT_API_KEY")
-FASTAPI_INVENTORY_API_KEY = os.getenv("FASTAPI_INVENTORY_API_KEY")
+FASTAPI_INVESTMENT_API_KEY: str | None = os.getenv(
+    "FASTAPI_INVESTMENT_API_KEY",
+)
+FASTAPI_INVENTORY_API_KEY: str | None = os.getenv(
+    "FASTAPI_INVENTORY_API_KEY",
+)
 
 # file paths
-TRANSACTION_PATH = os.getenv("TRANSACTION_PATH")
-TRANSACTION_SHEET_NAME = os.getenv("TRANSACTION_SHEET_NAME")
-DEFAULT_NAME = os.getenv("DEFAULT_NAME")
-BASE_PATH = os.getenv("BASE_PATH")
+TRANSACTION_PATH: str | None = os.getenv("TRANSACTION_PATH")
+TRANSACTION_SHEET_NAME: str | None = os.getenv("TRANSACTION_SHEET_NAME")
+DEFAULT_NAME: str | None = os.getenv("DEFAULT_NAME")
+BASE_PATH: str | None = os.getenv("BASE_PATH")
 
-REQUIRED_ENV_VARS = {
+REQUIRED_ENV_VARS: dict[str, str | None] = {
     "BASE_PATH": BASE_PATH,
     "TRANSACTION_PATH": TRANSACTION_PATH,
     "DEFAULT_NAME": DEFAULT_NAME,
 }
-missing_vars = [name for name, value in REQUIRED_ENV_VARS.items() if value is None]
+missing_vars: list[str] = [
+    name for name, value in REQUIRED_ENV_VARS.items() if value is None
+]
 if missing_vars:
     raise EnvironmentError(
         "Missing required environment variables: " + ", ".join(missing_vars)
     )
 
-TIMESERIES_DATA_PATH = BASE_PATH + "/timeseries_data"
-PORTFOLIO_PATH = BASE_PATH + "/portfolio"
+TIMESERIES_DATA_PATH: str = str(BASE_PATH) + "/timeseries_data"
+PORTFOLIO_PATH: str = str(BASE_PATH) + "/portfolio"

--- a/investment/core/security/composite.py
+++ b/investment/core/security/composite.py
@@ -6,10 +6,10 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-from ...utils.consts import OC
-from ..utils import get_currency_cross
 from .base import BaseSecurity
 from .currency_cross import CurrencyCross
+from ..utils import get_currency_cross
+from ...utils.consts import OC
 
 if TYPE_CHECKING:
     from ...datasource.base import BaseDataSource

--- a/investment/core/security/composite.py
+++ b/investment/core/security/composite.py
@@ -6,24 +6,26 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
+from ...utils.consts import OC
+from ..utils import get_currency_cross
 from .base import BaseSecurity
 from .currency_cross import CurrencyCross
-from ..utils import get_currency_cross
-from ...utils.consts import OC
 
 if TYPE_CHECKING:
     from ...datasource.base import BaseDataSource
 
+
 class Composite(BaseSecurity):
     """
     Composite Security.
-    
+
     Converts a given security (Security) with currency to a different
     currency using a CurrencyCross Security. Initalialised with:
         security (Security): The base security to convert
         currency_cross (opt, str): The currency to convert to
-        composite_currency (opt, CurrencyCross): The conversion security 
+        composite_currency (opt, CurrencyCross): The conversion security
     """
+
     entity_type: str = "composite"
     security: BaseSecurity
     currency_cross: CurrencyCross
@@ -38,15 +40,14 @@ class Composite(BaseSecurity):
             kwargs["composite_currency"] = currency_cross.currency
         elif composite_currency:
             kwargs["currency_cross"] = get_currency_cross(
-                origin_currency=security.currency,
-                result_currency=composite_currency
+                origin_currency=security.currency, result_currency=composite_currency
             )
 
         kwargs["code"] = f"{security.code}_{kwargs.get('composite_currency')}"
 
         super().__init__(**kwargs)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return debug representation."""
         pa = f"security={self.security.code}, currency_cross={self.currency_cross.code}"
         return f"Composite(entity_type={self.entity_type}, {pa})"
@@ -69,9 +70,8 @@ class Composite(BaseSecurity):
         ph_currency_cross = self.currency_cross.get_price_history(**kwargs)
 
         # exit early if required columns are not present
-        if (
-            not set(OC).issubset(ph_security.columns)
-            or not set(OC).issubset(ph_currency_cross.columns)
+        if not set(OC).issubset(ph_security.columns) or not set(OC).issubset(
+            ph_currency_cross.columns
         ):
             return pd.DataFrame()
 
@@ -82,14 +82,18 @@ class Composite(BaseSecurity):
         ph_currency_cross.columns = [f"{i}_ccy" for i in ph_currency_cross.columns]
 
         df = pd.merge(
-            left=ph_security, right=ph_currency_cross,
-            how="inner", left_index=True, right_index=True,
+            left=ph_security,
+            right=ph_currency_cross,
+            how="inner",
+            left_index=True,
+            right_index=True,
         ).dropna()
 
         df["open"] = df["open_sec"] * df["open_ccy"]
         df["close"] = df["close_sec"] * df["close_ccy"]
 
         return df[["open", "close"]]
+
 
 __all__ = [
     "Composite",

--- a/investment/core/security/generic.py
+++ b/investment/core/security/generic.py
@@ -1,8 +1,9 @@
 """Factory class used to initialise the correct security from a given code"""
 
-from typing import ClassVar
+from typing import ClassVar, Type
 
 from .base import BaseSecurity
+
 
 class Generic:
     """
@@ -18,7 +19,9 @@ class Generic:
 
     entity_type: ClassVar[str] = "generic"
 
-    def __new__(cls, code: str | None = None, **kwargs) -> "BaseSecurity":
+    def __new__(
+        cls: Type["Generic"], code: str | None = None, **kwargs
+    ) -> "BaseSecurity":
         """Initialise the wrapped security from local mapping."""
         from ...datasource.local import LocalDataSource
 
@@ -26,6 +29,7 @@ class Generic:
             kwargs["code"] = code
 
         return LocalDataSource().load_generic_security(**kwargs)
+
 
 __all__ = [
     "Generic",

--- a/investment/core/transactions.py
+++ b/investment/core/transactions.py
@@ -1,11 +1,18 @@
 """Defines Transaction class to find transactions data"""
 
 import warnings
+from typing import Any
 
 import pandas as pd
 from pydantic import BaseModel
 
-from ..config import TRANSACTION_PATH, TRANSACTION_SHEET_NAME, PORTFOLIO_PATH, DEFAULT_NAME
+from ..config import (
+    DEFAULT_NAME,
+    PORTFOLIO_PATH,
+    TRANSACTION_PATH,
+    TRANSACTION_SHEET_NAME,
+)
+
 
 class Transactions(BaseModel):
     """Helper for loading and saving portfolio transaction files."""
@@ -15,7 +22,7 @@ class Transactions(BaseModel):
     sheet_name: str = TRANSACTION_SHEET_NAME
     portfolio_path: str = PORTFOLIO_PATH
 
-    def __setattr__(self, name: str, value) -> None:
+    def __setattr__(self, name: str, value: Any) -> None:
         """Allow setting of arbitrary attributes for easier testing."""
         try:
             super().__setattr__(name, value)
@@ -28,17 +35,17 @@ class Transactions(BaseModel):
         """
         import_df = self._load_transactions()
 
-        transactions = import_df.loc[
-            import_df.Category == "Investments"
-        ][["Description", "Origin", "Date"]]
+        transactions = import_df.loc[import_df.Category == "Investments"][
+            ["Description", "Origin", "Date"]
+        ]
 
         pattern = (
-            r'^\s*'              # optional leading whitespace
-            r'(?P<figi_code>\S+)\s+'     # security code (non-whitespace)
-            r'(?P<direction>\S)\s+'      # direction (single character, e.g. 'B')
-            r'(?P<quantity>[\d\.]+)\s+'  # quantity (digits and decimals)
-            r'(?P<price>[\d\.]+)\s+'     # price (digits and decimals)
-            r'(?P<currency>\S+)\s*$'     # currency (non-whitespace) + optional trailing whitespace
+            r"^\s*"  # optional leading whitespace
+            r"(?P<figi_code>\S+)\s+"  # security code (non-whitespace)
+            r"(?P<direction>\S)\s+"  # direction (single character, e.g. 'B')
+            r"(?P<quantity>[\d\.]+)\s+"  # quantity (digits and decimals)
+            r"(?P<price>[\d\.]+)\s+"  # price (digits and decimals)
+            r"(?P<currency>\S+)\s*$"  # currency (non-whitespace) + optional trailing whitespace
         )
 
         df = transactions["Description"].str.extract(pattern)
@@ -56,13 +63,15 @@ class Transactions(BaseModel):
 
         df["quantity"] = df["quantity"].astype(float)
         df["price"] = df["price"].astype(float)
-        df["quantity"] = df["quantity"] * df["direction"].map({"B": 1, "S": -1}).fillna(0)
+        df["quantity"] = df["quantity"] * df["direction"].map({"B": 1, "S": -1}).fillna(
+            0
+        )
         df["account"] = transactions["Origin"].str[:-3]
         df["value"] = df["quantity"] * df["price"]
         df["as_of_date"] = pd.to_datetime(transactions["Date"])
 
         df = df.drop(columns=["direction"])
-        df = df.sort_values(['figi_code', 'as_of_date']).reset_index(drop=True)
+        df = df.sort_values(["figi_code", "as_of_date"]).reset_index(drop=True)
 
         df.to_csv(f"{self.portfolio_path}/{self.code}-transactions.csv", index=False)
 
@@ -74,16 +83,22 @@ class Transactions(BaseModel):
         import_df = import_df.set_index("Date")
 
         df = (
-            import_df[["Currency", "Net Value"]]
-            .sort_index()
-            .groupby(["Currency"])
-            .expanding()
-            .sum()
-        ).reset_index().rename(columns={
-            "Date": "as_of_date",
-            "Currency": "currency",
-            "Net Value": "value",
-        })
+            (
+                import_df[["Currency", "Net Value"]]
+                .sort_index()
+                .groupby(["Currency"])
+                .expanding()
+                .sum()
+            )
+            .reset_index()
+            .rename(
+                columns={
+                    "Date": "as_of_date",
+                    "Currency": "currency",
+                    "Net Value": "value",
+                }
+            )
+        )
 
         df["value"] = df["value"].round(2)
         df["change"] = df.groupby("currency")["value"].diff().fillna(df["value"])
@@ -99,6 +114,7 @@ class Transactions(BaseModel):
         """Run both extraction helpers to refresh portfolio files."""
         self.extract_and_save_investment_transactions()
         self.load_and_save_cash_positions()
+
 
 __all__ = [
     "Transactions",

--- a/investment/core/transactions.py
+++ b/investment/core/transactions.py
@@ -1,7 +1,7 @@
 """Defines Transaction class to find transactions data"""
 
-import warnings
 from typing import Any
+import warnings
 
 import pandas as pd
 from pydantic import BaseModel

--- a/investment/datasource/twelve_data.py
+++ b/investment/datasource/twelve_data.py
@@ -1,10 +1,10 @@
 """Data source wrapper for Twelve Data."""
 
 import datetime
-import warnings
 from itertools import product
 from time import sleep
 from typing import TYPE_CHECKING, Any, ClassVar
+import warnings
 
 import pandas as pd
 from pydantic import ConfigDict
@@ -12,10 +12,10 @@ from tqdm import tqdm
 from twelvedata import TDClient
 from twelvedata.exceptions import TwelveDataError
 
+from .base import BaseDataSource
 from ..config import TWELVE_DATA_API_KEY
 from ..utils.date_utils import today_midnight
 from ..utils.exceptions import TwelveDataException
-from .base import BaseDataSource
 
 if TYPE_CHECKING:
     from ..core.security.registry import (ETF, BaseSecurity, CurrencyCross,

--- a/run_tests.py
+++ b/run_tests.py
@@ -3,8 +3,8 @@
 from pathlib import Path
 from typing import Sequence
 
-import pytest
 from dotenv import load_dotenv
+import pytest
 
 
 def run_tests(args: Sequence[str] | None = None) -> int:

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,11 +1,13 @@
 """Expose a utility to run all relevant tests"""
 
 from pathlib import Path
+from typing import Sequence
 
-from dotenv import load_dotenv
 import pytest
+from dotenv import load_dotenv
 
-def run_tests(args=None):
+
+def run_tests(args: Sequence[str] | None = None) -> int:
     """Run all unit tests using pytest.
 
     Parameters
@@ -22,7 +24,8 @@ def run_tests(args=None):
     load_dotenv()
     if args is None:
         args = ["-q", str(Path(__file__).parent / "tests")]
-    return pytest.main(args)
+    return pytest.main(list(args))
+
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     raise SystemExit(run_tests())


### PR DESCRIPTION
## Summary
- annotate config constants
- type annotate run_tests util
- type annotate composite `__repr__`
- type annotate TwelveData rate limiter
- specify types for class methods and data loader helpers

## Testing
- `flake8 investment/core/transactions.py investment/core/security/generic.py investment/analytics/metrics.py investment/analytics/var.py run_tests.py`
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_687041b7edb88325ab5421c9f7463ba3