### PR TITLE
Run black and isort on tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ __pycache__/
 .env
 
 notebooks_scratch/
+
+# virtual environment
+.venv/
+
+# build artifacts
+investment.egg-info/

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,8 @@
 """Test suite configuration and environment variables."""
 
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 
 # Setup environment variables required for tests before importing config
 os.environ.setdefault("BASE_PATH", "/tmp")

--- a/tests/investment/test_base_analytics.py
+++ b/tests/investment/test_base_analytics.py
@@ -6,12 +6,14 @@ import pandas as pd
 
 from investment.analytics.base import BaseAnalytics
 
+
 class DummyAnalytics(BaseAnalytics):
     """Minimal subclass implementing registry for testing."""
 
     @staticmethod
     def registry() -> dict[str, callable]:
         return {}
+
 
 class BaseAnalyticsValidateTests(unittest.TestCase):
     """Test cases for :meth:`BaseAnalytics._validate`."""
@@ -23,7 +25,9 @@ class BaseAnalyticsValidateTests(unittest.TestCase):
         result = DummyAnalytics._validate(df)
         expected = df["close"].pct_change().dropna()
         expected.index.name = "as_of_date"
-        pd.testing.assert_series_equal(result, expected, check_freq=False, check_names=False)
+        pd.testing.assert_series_equal(
+            result, expected, check_freq=False, check_names=False
+        )
 
     def test_validate_errors(self):
         """Invalid input frames raise :class:`ValueError`."""

--- a/tests/investment/test_base_mapping_entity.py
+++ b/tests/investment/test_base_mapping_entity.py
@@ -8,6 +8,7 @@ import pandas as pd
 from investment.core.security import Equity
 from investment.datasource.test import TestDataSource
 
+
 class BaseMappingEntityTestCase(unittest.TestCase):
     """Tests for :class:`investment.core.mapping.BaseMappingEntity`."""
 
@@ -25,7 +26,12 @@ class BaseMappingEntityTestCase(unittest.TestCase):
         """Return a simple price history DataFrame for testing."""
 
         return pd.DataFrame(
-            {"close": [1.0, 2.0], "open": [1.0, 2.0], "high": [2.0, 3.0], "low": [0.5, 1.0]},
+            {
+                "close": [1.0, 2.0],
+                "open": [1.0, 2.0],
+                "high": [2.0, 3.0],
+                "low": [0.5, 1.0],
+            },
             index=pd.to_datetime(["2020-01-01", "2020-01-02"]),
         )
 
@@ -48,7 +54,9 @@ class BaseMappingEntityTestCase(unittest.TestCase):
         self.entity.get_price_history = mock.Mock(return_value=df_price)
         with mock.patch("investment.core.mapping.RealisedVolatilityCalculator") as rv:
             rv.return_value.calculate.return_value = df_vol
-            result = self.entity.get_realised_volatility(rv_model="close_to_close", rv_win_size=10)
+            result = self.entity.get_realised_volatility(
+                rv_model="close_to_close", rv_win_size=10
+            )
         rv.assert_called_once_with(rv_win_size=10, rv_model="close_to_close")
         rv.return_value.calculate.assert_called_once_with(df=df_price)
         self.assertIs(result, df_vol)
@@ -60,19 +68,24 @@ class BaseMappingEntityTestCase(unittest.TestCase):
         dfs = [pd.DataFrame({"metric": [i]}) for i in range(5)]
         with (
             mock.patch(
-                "investment.core.mapping.PerformanceMetrics.cumulative_return", return_value=dfs[0]
+                "investment.core.mapping.PerformanceMetrics.cumulative_return",
+                return_value=dfs[0],
             ) as m1,
             mock.patch(
-                "investment.core.mapping.PerformanceMetrics.annualised_return", return_value=dfs[1]
+                "investment.core.mapping.PerformanceMetrics.annualised_return",
+                return_value=dfs[1],
             ) as m2,
             mock.patch(
-                "investment.core.mapping.PerformanceMetrics.max_drawdown", return_value=dfs[2]
+                "investment.core.mapping.PerformanceMetrics.max_drawdown",
+                return_value=dfs[2],
             ) as m3,
             mock.patch(
-                "investment.core.mapping.PerformanceMetrics.sharpe_ratio", return_value=dfs[3]
+                "investment.core.mapping.PerformanceMetrics.sharpe_ratio",
+                return_value=dfs[3],
             ) as m4,
             mock.patch(
-                "investment.core.mapping.PerformanceMetrics.sortino_ratio", return_value=dfs[4]
+                "investment.core.mapping.PerformanceMetrics.sortino_ratio",
+                return_value=dfs[4],
             ) as m5,
         ):
             result = self.entity.get_performance_metrics(
@@ -97,9 +110,12 @@ class BaseMappingEntityTestCase(unittest.TestCase):
         self.entity.get_price_history = mock.Mock(return_value=df_price)
         mock_calc = mock.Mock(return_value=df_var)
         with mock.patch(
-            "investment.core.mapping.VaRCalculator.registry", return_value={"hist": mock_calc}
+            "investment.core.mapping.VaRCalculator.registry",
+            return_value={"hist": mock_calc},
         ) as reg:
-            result = self.entity.get_var(method="hist", var_win_size=3, confidence_level=0.95)
+            result = self.entity.get_var(
+                method="hist", var_win_size=3, confidence_level=0.95
+            )
         reg.assert_called_once()
         mock_calc.assert_called_once_with(
             df_price,
@@ -112,6 +128,8 @@ class BaseMappingEntityTestCase(unittest.TestCase):
         """``get_var`` raises ``KeyError`` when the method is unknown."""
         df_price = self._price_df()
         self.entity.get_price_history = mock.Mock(return_value=df_price)
-        with mock.patch("investment.core.mapping.VaRCalculator.registry", return_value={}):
+        with mock.patch(
+            "investment.core.mapping.VaRCalculator.registry", return_value={}
+        ):
             with self.assertRaises(KeyError):
                 self.entity.get_var(method="missing")

--- a/tests/investment/test_correlation.py
+++ b/tests/investment/test_correlation.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from investment.analytics import CorrelationCalculator
 
+
 class CorrelationCalculatorTests(unittest.TestCase):
     """Test cases for :class:`CorrelationCalculator`."""
 
@@ -53,10 +54,12 @@ class CorrelationCalculatorTests(unittest.TestCase):
 
     def test_semi_and_lagged(self):
         """Compute semi-correlation and lagged correlations."""
-        data = pd.DataFrame({
-            "a": [1.0, 2.0, 3.0, 4.0],
-            "b": [2.0, 1.0, 4.0, 3.0],
-        })
+        data = pd.DataFrame(
+            {
+                "a": [1.0, 2.0, 3.0, 4.0],
+                "b": [2.0, 1.0, 4.0, 3.0],
+            }
+        )
         calc = CorrelationCalculator()
         with mock.patch.object(calc, "_gather_series", return_value=data):
             semi = calc.semi(use_returns=False, downside=True)
@@ -77,9 +80,9 @@ class CorrelationCalculatorTests(unittest.TestCase):
         self.assertIn(0, lagged)
         self.assertIn(1, lagged)
         pd.testing.assert_frame_equal(lagged[0], corr0)
-        expected_lag1 = pd.DataFrame(index=["a","b"], columns=["a","b"], dtype=float)
+        expected_lag1 = pd.DataFrame(index=["a", "b"], columns=["a", "b"], dtype=float)
         val = data["a"].corr(data["b"].shift(1))
-        expected_lag1.loc["a","b"] = val
-        expected_lag1.loc["b","a"] = val
+        expected_lag1.loc["a", "b"] = val
+        expected_lag1.loc["b", "a"] = val
         np.fill_diagonal(expected_lag1.values, 1.0)
         pd.testing.assert_frame_equal(lagged[1], expected_lag1)

--- a/tests/investment/test_metrics.py
+++ b/tests/investment/test_metrics.py
@@ -8,6 +8,7 @@ import pandas as pd
 from investment.analytics import PerformanceMetrics
 from investment.utils.consts import TRADING_DAYS
 
+
 def sharpe_func(x: pd.Series) -> float:
     """Return the Sharpe ratio for an array of returns."""
     std = x.std()
@@ -15,9 +16,11 @@ def sharpe_func(x: pd.Series) -> float:
         return np.nan
     return x.mean() / std * np.sqrt(TRADING_DAYS)
 
+
 def hit_func(x: pd.Series) -> float:
     """Return the hit ratio for a window of returns."""
     return float((x > 0).sum() / len(x))
+
 
 def md_func(x: pd.Series) -> float:
     """Return the maximum drawdown for a window."""
@@ -26,12 +29,14 @@ def md_func(x: pd.Series) -> float:
     drawdown = (cum - running_max) / running_max
     return float(drawdown.min())
 
+
 def sortino_func(x: pd.Series) -> float:
     """Return the Sortino ratio for the returns."""
     downside = x[x < 0].std()
     if downside == 0:
         return np.nan
     return x.mean() / downside * np.sqrt(TRADING_DAYS)
+
 
 def dvol_func(x: pd.Series) -> float:
     """Return downside volatility for the returns."""
@@ -40,6 +45,7 @@ def dvol_func(x: pd.Series) -> float:
         return np.nan
     return d.std() * np.sqrt(TRADING_DAYS)
 
+
 def omega_func(x: pd.Series) -> float:
     """Return the Omega ratio for the returns."""
     pos = x[x > 0].sum()
@@ -47,6 +53,7 @@ def omega_func(x: pd.Series) -> float:
     if neg == 0:
         return np.nan
     return pos / neg
+
 
 class PerformanceMetricsTests(unittest.TestCase):
     """Test cases for :class:`PerformanceMetrics`."""

--- a/tests/investment/test_monte_carlo.py
+++ b/tests/investment/test_monte_carlo.py
@@ -4,11 +4,8 @@ import unittest
 
 import numpy as np
 
-from investment.analytics import (
-    BaseMonteCarloEngine,
-    PricePathEngine,
-    VolatilityEngine,
-)
+from investment.analytics import BaseMonteCarloEngine, PricePathEngine, VolatilityEngine
+
 
 class MonteCarloTests(unittest.TestCase):
     """Test cases for Monte Carlo path generation."""
@@ -17,7 +14,9 @@ class MonteCarloTests(unittest.TestCase):
         """Generate GBM and jump-diffusion paths consistently."""
         engine = PricePathEngine(n_steps=1, n_paths=2, random_state=0)
         spots = np.array([1.0])
-        paths = engine.generate_paths(spots=spots, drift=np.array([0.0]), vol=np.array([0.0]))
+        paths = engine.generate_paths(
+            spots=spots, drift=np.array([0.0]), vol=np.array([0.0])
+        )
         self.assertEqual(paths.shape, (2, 2, 1))
         self.assertTrue(np.all(paths[0] == spots))
 

--- a/tests/investment/test_portfolio.py
+++ b/tests/investment/test_portfolio.py
@@ -10,8 +10,10 @@ from investment.core.portfolio import Portfolio
 from investment.datasource.test import TestDataSource
 from investment.utils import consts
 
+
 class PortfolioTestCase(unittest.TestCase):
     """Test cases for :class:`~investment.core.portfolio.Portfolio`."""
+
     def setUp(self):
         patcher = mock.patch(
             "investment.core.mapping.BaseMappingEntity._local_datasource",
@@ -44,43 +46,47 @@ class PortfolioTestCase(unittest.TestCase):
 
     def test_get_holdings(self):
         """Holdings are correctly derived from transactions."""
-        tr_df = pd.DataFrame({
-            "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
-            "figi_code": ["AAA", "AAA"],
-            "quantity": [10, -5],
-            "value": [1000, -550],
-            "account": ["ACC1", "ACC1"],
-            "currency": ["GBP", "GBP"],
-        })
+        tr_df = pd.DataFrame(
+            {
+                "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
+                "figi_code": ["AAA", "AAA"],
+                "quantity": [10, -5],
+                "value": [1000, -550],
+                "account": ["ACC1", "ACC1"],
+                "currency": ["GBP", "GBP"],
+            }
+        )
         mapping_df = pd.DataFrame({"figi_code": ["AAA"], "code": ["AAA"]})
         pf = self._make_portfolio()
-        with mock.patch("pandas.read_csv", return_value=tr_df), \
-             mock.patch(
-                 "investment.core.portfolio.LocalDataSource.get_security_mapping",
-                 return_value=mapping_df
-                ):
+        with mock.patch("pandas.read_csv", return_value=tr_df), mock.patch(
+            "investment.core.portfolio.LocalDataSource.get_security_mapping",
+            return_value=mapping_df,
+        ):
             pf._get_holdings()
         expected = tr_df.copy()
         expected["cum_quantity"] = expected.groupby("figi_code")["quantity"].cumsum()
         expected["cum_value"] = expected.groupby("figi_code")["value"].cumsum()
         expected["average"] = expected["cum_value"] / expected["cum_quantity"]
-        expected = expected[["as_of_date", "figi_code", "cum_quantity", "average", "currency"]]
+        expected = expected[
+            ["as_of_date", "figi_code", "cum_quantity", "average", "currency"]
+        ]
         expected = expected.rename(columns={"cum_quantity": "quantity"})
         expected["entry_value"] = expected["quantity"] * expected["average"]
         expected = expected.merge(mapping_df, on="figi_code", how="left")
         pd.testing.assert_frame_equal(
-            pf.holdings.reset_index(drop=True),
-            expected.reset_index(drop=True)
+            pf.holdings.reset_index(drop=True), expected.reset_index(drop=True)
         )
 
     def test_get_cash_filters(self):
         """Cash loading respects account and currency filters."""
-        cash_df = pd.DataFrame({
-            "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
-            "account": ["ACC1", "ACC2"],
-            "currency": ["GBP", "GBP"],
-            "value": [100, 200],
-        })
+        cash_df = pd.DataFrame(
+            {
+                "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
+                "account": ["ACC1", "ACC2"],
+                "currency": ["GBP", "GBP"],
+                "value": [100, 200],
+            }
+        )
         pf = self._make_portfolio(has_cash=True, account="ACC1", currency="GBP")
         with mock.patch("pandas.read_csv", return_value=cash_df):
             pf._get_cash()
@@ -89,19 +95,22 @@ class PortfolioTestCase(unittest.TestCase):
 
     def test_prepare_holdings_timeseries(self):
         """Prepared holdings return expected columns."""
-        holdings = pd.DataFrame({
-            "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
-            "figi_code": ["AAA", "AAA"],
-            "quantity": [10, 5],
-            "average": [100.0, 90.0],
-            "currency": ["GBP", "GBP"],
-            "entry_value": [1000.0, 450.0],
-            "code": ["AAA", "AAA"],
-        })
+        holdings = pd.DataFrame(
+            {
+                "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
+                "figi_code": ["AAA", "AAA"],
+                "quantity": [10, 5],
+                "average": [100.0, 90.0],
+                "currency": ["GBP", "GBP"],
+                "entry_value": [1000.0, 450.0],
+                "code": ["AAA", "AAA"],
+            }
+        )
         pf = self._make_portfolio()
         pf.holdings = holdings
         with mock.patch(
-            "investment.core.portfolio.today_midnight", return_value=pd.Timestamp("2020-01-02")
+            "investment.core.portfolio.today_midnight",
+            return_value=pd.Timestamp("2020-01-02"),
         ):
             result = pf._prepare_holdings_timeseries()
         self.assertEqual(len(result), 2)
@@ -111,47 +120,49 @@ class PortfolioTestCase(unittest.TestCase):
     def test_get_holdings_price_history_no_prices(self):
         """Holdings price history returns holdings when no prices."""
         pf = self._make_portfolio()
-        base_df = pd.DataFrame({
-            "as_of_date": [pd.Timestamp("2020-01-01")],
-            "currency": ["GBP"],
-            "figi_code": ["AAA"],
-            "code": ["AAA"],
-            "quantity": [10.0],
-            "average": [100.0],
-            "entry_value": [1000.0],
-        })
+        base_df = pd.DataFrame(
+            {
+                "as_of_date": [pd.Timestamp("2020-01-01")],
+                "currency": ["GBP"],
+                "figi_code": ["AAA"],
+                "code": ["AAA"],
+                "quantity": [10.0],
+                "average": [100.0],
+                "entry_value": [1000.0],
+            }
+        )
         with mock.patch.object(
             Portfolio, "_prepare_holdings_timeseries", return_value=base_df
-        ), \
-             mock.patch.object(
-                 Portfolio, "_combine_with_security_price_history", return_value=base_df
-             ):
+        ), mock.patch.object(
+            Portfolio, "_combine_with_security_price_history", return_value=base_df
+        ):
             result = pf.get_holdings_price_history()
         pd.testing.assert_frame_equal(result, base_df)
 
     def test_get_holdings_price_history_with_prices(self):
         """Holdings price history merges security prices."""
         pf = self._make_portfolio()
-        base = pd.DataFrame({
-            "as_of_date": [pd.Timestamp("2020-01-01")],
-            "currency": ["GBP"],
-            "figi_code": ["AAA"],
-            "code": ["AAA"],
-            "quantity": [10.0],
-            "average": [100.0],
-            "entry_value": [1000.0],
-            "open": [101.0],
-            "close": [102.0],
-            "high": [103.0],
-            "low": [99.0],
-        })
+        base = pd.DataFrame(
+            {
+                "as_of_date": [pd.Timestamp("2020-01-01")],
+                "currency": ["GBP"],
+                "figi_code": ["AAA"],
+                "code": ["AAA"],
+                "quantity": [10.0],
+                "average": [100.0],
+                "entry_value": [1000.0],
+                "open": [101.0],
+                "close": [102.0],
+                "high": [103.0],
+                "low": [99.0],
+            }
+        )
         base_no_price = base.drop(columns=consts.OHLC)
         with mock.patch.object(
             Portfolio, "_prepare_holdings_timeseries", return_value=base_no_price
-        ), \
-             mock.patch.object(
-                 Portfolio, "_combine_with_security_price_history", return_value=base
-             ):
+        ), mock.patch.object(
+            Portfolio, "_combine_with_security_price_history", return_value=base
+        ):
             result = pf.get_holdings_price_history()
         self.assertIn("open_value", result.columns)
         self.assertEqual(result.loc[0, "open_value"], 1010.0)
@@ -160,23 +171,33 @@ class PortfolioTestCase(unittest.TestCase):
     def test_get_price_history(self):
         """Aggregated price history sums underlying holdings."""
         pf = self._make_portfolio()
-        ph = pd.DataFrame({
-            "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
-            "open_value": [100.0, 200.0],
-            "close_value": [110.0, 210.0],
-            "net_value": [10.0, 20.0],
-            "entry_value": [90.0, 195.0],
-        })
-        with mock.patch.object(Portfolio, "get_holdings_price_history", return_value=ph):
+        ph = pd.DataFrame(
+            {
+                "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
+                "open_value": [100.0, 200.0],
+                "close_value": [110.0, 210.0],
+                "net_value": [10.0, 20.0],
+                "entry_value": [90.0, 195.0],
+            }
+        )
+        with mock.patch.object(
+            Portfolio, "get_holdings_price_history", return_value=ph
+        ):
             result = pf.get_price_history()
-        expected = ph.groupby("as_of_date")[
-            [f"{i}_value" for i in consts.OC + ["net", "entry"]]
-        ].sum().rename(columns={
-            "open_value": "open",
-            "close_value": "close",
-            "net_value": "net",
-            "entry_value": "entry",
-        })
+        expected = (
+            ph.groupby("as_of_date")[
+                [f"{i}_value" for i in consts.OC + ["net", "entry"]]
+            ]
+            .sum()
+            .rename(
+                columns={
+                    "open_value": "open",
+                    "close_value": "close",
+                    "net_value": "net",
+                    "entry_value": "entry",
+                }
+            )
+        )
         pd.testing.assert_frame_equal(result, expected)
 
     def test_all_securities(self):
@@ -193,12 +214,13 @@ class PortfolioTestCase(unittest.TestCase):
 
     def test_init_triggers_loading(self):
         """Ensure ``__init__`` loads holdings and cash."""
-        with mock.patch.object(Portfolio, "_load_cash_and_holdings") as mch, \
-             mock.patch.dict(
-                 Portfolio.__fields__,
-                 {"entity_type": mock.Mock(default="portfolio")},
-                 clear=False,
-             ):
+        with mock.patch.object(
+            Portfolio, "_load_cash_and_holdings"
+        ) as mch, mock.patch.dict(
+            Portfolio.__fields__,
+            {"entity_type": mock.Mock(default="portfolio")},
+            clear=False,
+        ):
             pf = Portfolio("TEST")
         mch.assert_called_once()
         self.assertEqual(pf.code, "TEST")
@@ -206,15 +228,17 @@ class PortfolioTestCase(unittest.TestCase):
     def test_load_cash_and_holdings_calls(self):
         """_load_cash_and_holdings delegates to cash and holdings helpers."""
         pf = self._make_portfolio(has_cash=True)
-        with mock.patch.object(pf, "_get_holdings") as gh, \
-             mock.patch.object(pf, "_get_cash") as gc:
+        with mock.patch.object(pf, "_get_holdings") as gh, mock.patch.object(
+            pf, "_get_cash"
+        ) as gc:
             pf._load_cash_and_holdings()
         gh.assert_called_once()
         gc.assert_called_once()
 
         pf = self._make_portfolio(has_cash=True, ignore_cash=True)
-        with mock.patch.object(pf, "_get_holdings") as gh, \
-             mock.patch.object(pf, "_get_cash") as gc:
+        with mock.patch.object(pf, "_get_holdings") as gh, mock.patch.object(
+            pf, "_get_cash"
+        ) as gc:
             pf._load_cash_and_holdings()
         gh.assert_called_once()
         gc.assert_not_called()
@@ -222,8 +246,9 @@ class PortfolioTestCase(unittest.TestCase):
     def test_update_calls_transactions_update(self):
         """update refreshes transactions and reloads data."""
         pf = self._make_portfolio()
-        with mock.patch("investment.core.portfolio.Transactions.update") as tu, \
-             mock.patch.object(pf, "_load_cash_and_holdings") as lch:
+        with mock.patch(
+            "investment.core.portfolio.Transactions.update"
+        ) as tu, mock.patch.object(pf, "_load_cash_and_holdings") as lch:
             pf.update()
         tu.assert_called_once()
         lch.assert_called_once()
@@ -231,8 +256,9 @@ class PortfolioTestCase(unittest.TestCase):
     def test_update_invalid_code(self):
         """update raises when Portfolio code mismatches."""
         pf = self._make_portfolio(code="OTHER")
-        with mock.patch("investment.core.portfolio.Transactions.update") as tu, \
-             mock.patch.object(pf, "_load_cash_and_holdings") as lch:
+        with mock.patch(
+            "investment.core.portfolio.Transactions.update"
+        ) as tu, mock.patch.object(pf, "_load_cash_and_holdings") as lch:
             with self.assertRaises(Exception):
                 pf.update()
         tu.assert_not_called()
@@ -241,24 +267,31 @@ class PortfolioTestCase(unittest.TestCase):
     def test_combine_with_security_price_history(self):
         """Security price history is merged and forward filled."""
         pf = self._make_portfolio()
-        df = pd.DataFrame({
-            "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
-            "currency": ["GBP", "GBP"],
-            "figi_code": ["AAA", "AAA"],
-            "code": ["AAA", "AAA"],
-            "quantity": [1.0, 1.0],
-            "average": [100.0, 100.0],
-            "entry_value": [100.0, 100.0],
-        })
-        ph = pd.DataFrame({
-            "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
-            "close": [10.0, 20.0],
-        }).set_index("as_of_date")
+        df = pd.DataFrame(
+            {
+                "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
+                "currency": ["GBP", "GBP"],
+                "figi_code": ["AAA", "AAA"],
+                "code": ["AAA", "AAA"],
+                "quantity": [1.0, 1.0],
+                "average": [100.0, 100.0],
+                "entry_value": [100.0, 100.0],
+            }
+        )
+        ph = pd.DataFrame(
+            {
+                "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
+                "close": [10.0, 20.0],
+            }
+        ).set_index("as_of_date")
         sec = mock.Mock()
         sec.code = "AAA"
         sec.get_price_history.return_value = ph
         with mock.patch.object(
-            Portfolio, "all_securities", new_callable=mock.PropertyMock, return_value=[sec]
+            Portfolio,
+            "all_securities",
+            new_callable=mock.PropertyMock,
+            return_value=[sec],
         ):
             result = pf._combine_with_security_price_history(df, currency="GBP")
 
@@ -268,9 +301,11 @@ class PortfolioTestCase(unittest.TestCase):
             how="left",
         )
         expected = expected.sort_values(by=["code", "figi_code", "as_of_date"])
-        expected = expected.set_index(
-            ["code", "figi_code"]
-        ).groupby(level=0, group_keys=False).ffill()
+        expected = (
+            expected.set_index(["code", "figi_code"])
+            .groupby(level=0, group_keys=False)
+            .ffill()
+        )
         expected = expected.set_index("as_of_date", append=True)
 
         pd.testing.assert_frame_equal(result, expected)
@@ -281,32 +316,40 @@ class PortfolioTestCase(unittest.TestCase):
     def test_get_price_history_intraday_warns(self):
         """Passing intraday=True emits a warning and aggregates correctly."""
         pf = self._make_portfolio()
-        df = pd.DataFrame({
-            "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-01"]),
-            "open_value": [1.0, 2.0],
-            "close_value": [1.5, 2.5],
-            "net_value": [0.5, 0.5],
-            "entry_value": [1.0, 2.0],
-        })
+        df = pd.DataFrame(
+            {
+                "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-01"]),
+                "open_value": [1.0, 2.0],
+                "close_value": [1.5, 2.5],
+                "net_value": [0.5, 0.5],
+                "entry_value": [1.0, 2.0],
+            }
+        )
         with mock.patch.object(
-            Portfolio,
-            "get_holdings_price_history",
-            return_value=df
+            Portfolio, "get_holdings_price_history", return_value=df
         ) as gh:
             with self.assertWarns(UserWarning):
                 result = pf.get_price_history(intraday=True)
         gh.assert_called_once()
-        expected = df.groupby("as_of_date")[[
-            "open_value",
-            "close_value",
-            "net_value",
-            "entry_value",
-        ]].sum().rename(columns={
-            "open_value": "open",
-            "close_value": "close",
-            "net_value": "net",
-            "entry_value": "entry",
-        })
+        expected = (
+            df.groupby("as_of_date")[
+                [
+                    "open_value",
+                    "close_value",
+                    "net_value",
+                    "entry_value",
+                ]
+            ]
+            .sum()
+            .rename(
+                columns={
+                    "open_value": "open",
+                    "close_value": "close",
+                    "net_value": "net",
+                    "entry_value": "entry",
+                }
+            )
+        )
         pd.testing.assert_frame_equal(result, expected)
 
     def test_transactions_reads_csv(self):
@@ -317,37 +360,42 @@ class PortfolioTestCase(unittest.TestCase):
             result = pf.transactions
         rc.assert_called_once_with(
             f"{config.PORTFOLIO_PATH}/TEST-transactions.csv",
-            parse_dates=['as_of_date'],
+            parse_dates=["as_of_date"],
         )
         self.assertIs(result, df)
 
     def test_get_holdings_filters_account_currency(self):
         """_get_holdings applies account and currency filters."""
-        tr_df = pd.DataFrame({
-            "as_of_date": pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]),
-            "figi_code": ["AAA", "AAA", "AAA"],
-            "quantity": [5, 5, 5],
-            "value": [50, 60, 70],
-            "account": ["ACC1", "ACC2", "ACC1"],
-            "currency": ["USD", "USD", "EUR"],
-        })
+        tr_df = pd.DataFrame(
+            {
+                "as_of_date": pd.to_datetime(
+                    ["2020-01-01", "2020-01-02", "2020-01-03"]
+                ),
+                "figi_code": ["AAA", "AAA", "AAA"],
+                "quantity": [5, 5, 5],
+                "value": [50, 60, 70],
+                "account": ["ACC1", "ACC2", "ACC1"],
+                "currency": ["USD", "USD", "EUR"],
+            }
+        )
         mapping_df = pd.DataFrame({"figi_code": ["AAA"], "code": ["AAA"]})
         pf = self._make_portfolio(account="ACC1", currency="USD")
-        with mock.patch("pandas.read_csv", return_value=tr_df), \
-             mock.patch(
-                 "investment.core.portfolio.LocalDataSource.get_security_mapping",
-                 return_value=mapping_df,
-             ):
+        with mock.patch("pandas.read_csv", return_value=tr_df), mock.patch(
+            "investment.core.portfolio.LocalDataSource.get_security_mapping",
+            return_value=mapping_df,
+        ):
             pf._get_holdings()
-        expected = pd.DataFrame({
-            "as_of_date": pd.to_datetime(["2020-01-01"]),
-            "figi_code": ["AAA"],
-            "quantity": [5.0],
-            "average": [10.0],
-            "currency": ["USD"],
-            "entry_value": [50.0],
-            "code": ["AAA"],
-        })
+        expected = pd.DataFrame(
+            {
+                "as_of_date": pd.to_datetime(["2020-01-01"]),
+                "figi_code": ["AAA"],
+                "quantity": [5.0],
+                "average": [10.0],
+                "currency": ["USD"],
+                "entry_value": [50.0],
+                "code": ["AAA"],
+            }
+        )
         pd.testing.assert_frame_equal(
             pf.holdings.reset_index(drop=True), expected, check_dtype=False
         )

--- a/tests/investment/test_random_generators.py
+++ b/tests/investment/test_random_generators.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from investment.analytics import RandomGenerator
 
+
 class RandomGeneratorTests(unittest.TestCase):
     """Test cases for :class:`RandomGenerator`."""
 

--- a/tests/investment/test_realised_volatility.py
+++ b/tests/investment/test_realised_volatility.py
@@ -8,6 +8,7 @@ import pandas as pd
 from investment.analytics import RealisedVolatilityCalculator
 from investment.utils.consts import TRADING_DAYS
 
+
 class RealisedVolatilityTests(unittest.TestCase):
     """Test cases for :class:`RealisedVolatilityCalculator`."""
 
@@ -99,7 +100,7 @@ class RealisedVolatilityTests(unittest.TestCase):
         log_co = log_close - log_open
         var_on = log_oc.rolling(2).var()
         var_day = log_co.rolling(2).var()
-        rs2 = exp_rs ** 2  # rogers-satchell already annualised
+        rs2 = exp_rs**2  # rogers-satchell already annualised
         k = 0.34 / (1.34 + (2 + 1) / (2 - 1))
         exp_yz = np.sqrt(var_on + k * var_day + (1 - k) * rs2)
         res_yz = result[result["rv_model"] == "yang_zhang"]["volatility"]

--- a/tests/investment/test_returns.py
+++ b/tests/investment/test_returns.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from investment.analytics import ReturnsCalculator
 
+
 class ReturnsCalculatorTests(unittest.TestCase):
     """Test cases for :class:`ReturnsCalculator`."""
 
@@ -31,9 +32,11 @@ class ReturnsCalculatorTests(unittest.TestCase):
             calc.calculate(bad_df)
 
         with self.assertRaises(ValueError):
-            calc.calculate(pd.DataFrame(
-                {"open": [1, 2, 3]}, index=pd.date_range("2020", periods=3)
-            ))
+            calc.calculate(
+                pd.DataFrame(
+                    {"open": [1, 2, 3]}, index=pd.date_range("2020", periods=3)
+                )
+            )
 
     def test_multiple_windows(self):
         """Support multiple rolling return windows."""
@@ -43,12 +46,28 @@ class ReturnsCalculatorTests(unittest.TestCase):
         result = calc.calculate(df)
         simple1 = df["close"].pct_change(1)
         simple2 = df["close"].pct_change(2)
-        expected = pd.concat([
-            pd.DataFrame(
-                {"as_of_date": dates, "is_ln_ret": False, "ret_win_size": 1, "return": simple1}
-            ),
-            pd.DataFrame(
-                {"as_of_date": dates, "is_ln_ret": False, "ret_win_size": 2, "return": simple2}
-            ),
-        ]).dropna().reset_index(drop=True)
+        expected = (
+            pd.concat(
+                [
+                    pd.DataFrame(
+                        {
+                            "as_of_date": dates,
+                            "is_ln_ret": False,
+                            "ret_win_size": 1,
+                            "return": simple1,
+                        }
+                    ),
+                    pd.DataFrame(
+                        {
+                            "as_of_date": dates,
+                            "is_ln_ret": False,
+                            "ret_win_size": 2,
+                            "return": simple2,
+                        }
+                    ),
+                ]
+            )
+            .dropna()
+            .reset_index(drop=True)
+        )
         pd.testing.assert_frame_equal(result, expected)

--- a/tests/investment/test_security.py
+++ b/tests/investment/test_security.py
@@ -1,24 +1,25 @@
 """Unit tests for the security module and related classes."""
 
-from unittest import TestCase
-from unittest import mock
+from unittest import TestCase, mock
 
 import pandas as pd
 
 from investment import config
 from investment.core.security import (
+    ETF,
     Composite,
     CurrencyCross,
     Equity,
-    ETF,
     Fund,
     Generic,
     security_registry,
 )
 from investment.datasource.test import TestDataSource
 
+
 class SecurityTestCase(TestCase):
     """Test cases for security classes and their methods."""
+
     def setUp(self):
         """Set up the test case environment."""
         # Mock the local datasource to use the test data source
@@ -57,21 +58,27 @@ class SecurityTestCase(TestCase):
         ) as MockComposite:
             comp_instance = MockComposite.return_value
             result = sec.convert_to_currency("EUR")
-            MockComposite.assert_called_once_with(security=sec, composite_currency="EUR")
+            MockComposite.assert_called_once_with(
+                security=sec, composite_currency="EUR"
+            )
             self.assertIs(result, comp_instance)
 
     def test_get_price_history_self_currency(self):
         """Test getting price history in the security's own currency."""
         sec = Equity("TEST")
-        df = pd.DataFrame({
-            "as_of_date": [pd.Timestamp("2020-01-01")],
-            "open": [1],
-            "close": [2],
-        })
+        df = pd.DataFrame(
+            {
+                "as_of_date": [pd.Timestamp("2020-01-01")],
+                "open": [1],
+                "close": [2],
+            }
+        )
         ds = TestDataSource()
         with mock.patch(
             "investment.core.security.base.get_datasource", return_value=ds
-        ) as mock_gds, mock.patch.object(ds, "get_price_history", return_value=df) as gp:
+        ) as mock_gds, mock.patch.object(
+            ds, "get_price_history", return_value=df
+        ) as gp:
             result = sec.get_price_history(datasource=ds)
         mock_gds.assert_called_once_with(datasource=ds)
         gp.assert_called_once_with(security=sec, intraday=False, local_only=True)
@@ -126,8 +133,7 @@ class SecurityTestCase(TestCase):
             index=pd.to_datetime(["2020-01-01", "2020-01-02"]),
         )
         pd.testing.assert_frame_equal(
-            result.reset_index(drop=True),
-            expected.reset_index(drop=True)
+            result.reset_index(drop=True), expected.reset_index(drop=True)
         )
 
     def test_generic_factory(self):
@@ -161,7 +167,7 @@ class SecurityTestCase(TestCase):
         comp = Composite(security=sec, currency_cross=cc)
         self.assertEqual(
             repr(comp),
-            "Composite(entity_type=composite, security=AAA, currency_cross=EURUSD)"
+            "Composite(entity_type=composite, security=AAA, currency_cross=EURUSD)",
         )
 
     def test_get_file_path_open_figi(self):

--- a/tests/investment/test_security_modules.py
+++ b/tests/investment/test_security_modules.py
@@ -3,11 +3,13 @@
 import unittest
 from unittest import mock
 
-from investment.core.security import CurrencyCross, Equity, ETF, Fund, ISINSecurity
+from investment.core.security import ETF, CurrencyCross, Equity, Fund, ISINSecurity
 from investment.datasource.test import TestDataSource
+
 
 class SecurityModulesTestCase(unittest.TestCase):
     """Test cases for security module initialisation."""
+
     def setUp(self):
         """Set up the test case environment."""
         # Mock the local datasource to use the test data source

--- a/tests/investment/test_transactions.py
+++ b/tests/investment/test_transactions.py
@@ -1,33 +1,37 @@
 """Test cases for :class:`~investment.core.transactions.Transactions`."""
 
 import unittest
-from unittest import mock
 import warnings
+from unittest import mock
 
 import pandas as pd
 
 from investment import config
 from investment.core.transactions import Transactions
 
+
 class TransactionsTestCase(unittest.TestCase):
     """Test cases for :class:`~investment.core.transactions.Transactions`."""
 
     def test_extract_and_save_investment_transactions_1(self):
         """Rows not matching the pattern are dropped with a warning."""
-        raw_df = pd.DataFrame({
-            "Category": ["Investments", "Investments", "Investments"],
-            "Description": [
-                "AAA B 10 100 GBP",
-                "BAD DATA",
-                "BBB S 2 50 USD",
-            ],
-            "Origin": ["ACC1000", "ACC1000", "ACC2000"],
-            "Date": ["2020-01-01", "2020-01-03", "2020-01-02"],
-        })
+        raw_df = pd.DataFrame(
+            {
+                "Category": ["Investments", "Investments", "Investments"],
+                "Description": [
+                    "AAA B 10 100 GBP",
+                    "BAD DATA",
+                    "BBB S 2 50 USD",
+                ],
+                "Origin": ["ACC1000", "ACC1000", "ACC2000"],
+                "Date": ["2020-01-01", "2020-01-03", "2020-01-02"],
+            }
+        )
 
         tx = Transactions()
-        with mock.patch.object(Transactions, "_load_transactions", return_value=raw_df), \
-             mock.patch.object(pd.DataFrame, "to_csv", autospec=True) as m_csv:
+        with mock.patch.object(
+            Transactions, "_load_transactions", return_value=raw_df
+        ), mock.patch.object(pd.DataFrame, "to_csv", autospec=True) as m_csv:
             with self.assertWarns(UserWarning):
                 tx.extract_and_save_investment_transactions()
 
@@ -53,19 +57,22 @@ class TransactionsTestCase(unittest.TestCase):
 
     def test_extract_and_save_investment_transactions_all_match(self):
         """All rows are kept when every description matches the pattern."""
-        clean_df = pd.DataFrame({
-            "Category": ["Investments", "Investments"],
-            "Description": [
-                "AAA B 10 100 GBP",
-                "BBB S 2 50 USD",
-            ],
-            "Origin": ["ACC1000", "ACC2000"],
-            "Date": ["2020-01-01", "2020-01-02"],
-        })
+        clean_df = pd.DataFrame(
+            {
+                "Category": ["Investments", "Investments"],
+                "Description": [
+                    "AAA B 10 100 GBP",
+                    "BBB S 2 50 USD",
+                ],
+                "Origin": ["ACC1000", "ACC2000"],
+                "Date": ["2020-01-01", "2020-01-02"],
+            }
+        )
 
         tx = Transactions()
-        with mock.patch.object(Transactions, "_load_transactions", return_value=clean_df), \
-             mock.patch.object(pd.DataFrame, "to_csv", autospec=True) as m_csv:
+        with mock.patch.object(
+            Transactions, "_load_transactions", return_value=clean_df
+        ), mock.patch.object(pd.DataFrame, "to_csv", autospec=True) as m_csv:
             with warnings.catch_warnings(record=True) as w:
                 tx.extract_and_save_investment_transactions()
             self.assertEqual(len(w), 0)
@@ -97,9 +104,7 @@ class TransactionsTestCase(unittest.TestCase):
 
     def test_load_transactions(self):
         """Verify the helper correctly loads from Excel."""
-        tr = self._make_transactions(
-            file_path="/tmp/file.xlsx", sheet_name="Sheet1"
-        )
+        tr = self._make_transactions(file_path="/tmp/file.xlsx", sheet_name="Sheet1")
         df = pd.DataFrame()
         with mock.patch("pandas.read_excel", return_value=df) as re:
             result = tr._load_transactions()
@@ -131,9 +136,7 @@ class TransactionsTestCase(unittest.TestCase):
                 ],
             }
         )
-        tr = self._make_transactions(
-            code="TEST", portfolio_path="/tmp/portfolio"
-        )
+        tr = self._make_transactions(code="TEST", portfolio_path="/tmp/portfolio")
 
         captured = {}
 
@@ -142,15 +145,13 @@ class TransactionsTestCase(unittest.TestCase):
             captured["path"] = path
             captured["index"] = index
 
-        with mock.patch.object(
-            tr, "_load_transactions", return_value=raw
-        ), mock.patch("pandas.DataFrame.to_csv", new=fake_to_csv):
+        with mock.patch.object(tr, "_load_transactions", return_value=raw), mock.patch(
+            "pandas.DataFrame.to_csv", new=fake_to_csv
+        ):
             with self.assertWarns(UserWarning):
                 tr.extract_and_save_investment_transactions()
 
-        self.assertEqual(
-            captured["path"], "/tmp/portfolio/TEST-transactions.csv"
-        )
+        self.assertEqual(captured["path"], "/tmp/portfolio/TEST-transactions.csv")
         self.assertFalse(captured["index"])
 
         expected = pd.DataFrame(
@@ -167,9 +168,7 @@ class TransactionsTestCase(unittest.TestCase):
                 ],
             }
         )
-        pd.testing.assert_frame_equal(
-            captured["df"].reset_index(drop=True), expected
-        )
+        pd.testing.assert_frame_equal(captured["df"].reset_index(drop=True), expected)
 
     def test_load_and_save_cash_positions(self):
         """Cash positions are aggregated and saved to CSV."""
@@ -184,9 +183,7 @@ class TransactionsTestCase(unittest.TestCase):
                 "Net Value": [10, 5, 7],
             }
         )
-        tr = self._make_transactions(
-            code="TEST", portfolio_path="/tmp/portfolio"
-        )
+        tr = self._make_transactions(code="TEST", portfolio_path="/tmp/portfolio")
 
         captured = {}
 
@@ -195,9 +192,9 @@ class TransactionsTestCase(unittest.TestCase):
             captured["path"] = path
             captured["index"] = index
 
-        with mock.patch.object(
-            tr, "_load_transactions", return_value=raw
-        ), mock.patch("pandas.DataFrame.to_csv", new=fake_to_csv):
+        with mock.patch.object(tr, "_load_transactions", return_value=raw), mock.patch(
+            "pandas.DataFrame.to_csv", new=fake_to_csv
+        ):
             tr.load_and_save_cash_positions()
 
         self.assertEqual(captured["path"], "/tmp/portfolio/TEST-cash.csv")
@@ -213,9 +210,7 @@ class TransactionsTestCase(unittest.TestCase):
                 "change": [7.0, 10.0, 5.0],
             }
         )
-        pd.testing.assert_frame_equal(
-            captured["df"].reset_index(drop=True), expected
-        )
+        pd.testing.assert_frame_equal(captured["df"].reset_index(drop=True), expected)
 
     def test_update_calls_helpers(self):
         """``update`` invokes both extraction helpers."""

--- a/tests/investment/test_var.py
+++ b/tests/investment/test_var.py
@@ -1,18 +1,20 @@
 """Unit tests for the :mod:`investment.analytics.var` module."""
 
-from statistics import NormalDist
 import unittest
+from statistics import NormalDist
 
 import numpy as np
 import pandas as pd
 
 from investment.analytics import VaRCalculator
 
+
 def _cond_var(x: pd.Series) -> float:
     """Return the conditional VaR for a returns window."""
     var_thresh = -x.quantile(0.05)
     tail = x[x <= -var_thresh]
     return -tail.mean() if not tail.empty else var_thresh
+
 
 class VaRCalculatorTests(unittest.TestCase):
     """Test cases for :class:`VaRCalculator`."""
@@ -23,15 +25,21 @@ class VaRCalculatorTests(unittest.TestCase):
 
     def test_historical_var(self):
         """Historical VaR matches rolling quantiles."""
-        var = VaRCalculator.historical_var(self.df, var_win_size=3, confidence_level=0.95)
+        var = VaRCalculator.historical_var(
+            self.df, var_win_size=3, confidence_level=0.95
+        )
         returns = self.df["close"].pct_change().dropna()
         expected = returns.rolling(3).apply(lambda x: -x.quantile(0.05))
         np.testing.assert_allclose(var["var"], expected.dropna())
 
     def test_parametric_and_conditional_var(self):
         """Parametric and conditional VaR calculations agree with formulas."""
-        param = VaRCalculator.parametric_var(self.df, var_win_size=3, confidence_level=0.95)
-        cond = VaRCalculator.conditional_var(self.df, var_win_size=3, confidence_level=0.95)
+        param = VaRCalculator.parametric_var(
+            self.df, var_win_size=3, confidence_level=0.95
+        )
+        cond = VaRCalculator.conditional_var(
+            self.df, var_win_size=3, confidence_level=0.95
+        )
 
         returns = self.df["close"].pct_change().dropna()
         z = NormalDist().inv_cdf(1 - 0.95)
@@ -45,7 +53,9 @@ class VaRCalculatorTests(unittest.TestCase):
         df_up = pd.DataFrame(
             {"close": [1, 2, 3, 4, 5]}, index=pd.date_range("2020-01-01", periods=5)
         )
-        result = VaRCalculator.conditional_var(df_up, var_win_size=2, confidence_level=0.95)
+        result = VaRCalculator.conditional_var(
+            df_up, var_win_size=2, confidence_level=0.95
+        )
         returns = df_up["close"].pct_change().dropna()
 
         expected = returns.rolling(2).apply(_cond_var)


### PR DESCRIPTION
## Summary
- format all tests with `isort` and `black`
- ignore `.venv` and build artifacts

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6873f8aeff288325a66593b52f7a2cef