### PR TITLE
Fix BaseAnalytics validation

### DIFF
--- a/investment/analytics/base.py
+++ b/investment/analytics/base.py
@@ -17,7 +17,6 @@ class BaseAnalytics:
     @staticmethod
     def _validate(df: DataFrame) -> Series:
         """Validate input DataFrame and return simple returns series."""
-        from . import ReturnsCalculator # TODO avoid circular import
 
         if df.empty:
             raise ValueError("Input DataFrame is empty.")
@@ -26,8 +25,9 @@ class BaseAnalytics:
         if not isinstance(df.index, DatetimeIndex):
             raise ValueError("DataFrame index must be a DatetimeIndex.")
 
-        ret_df = ReturnsCalculator(use_ln_ret=False, ret_win_size=1).calculate(df)
-        return ret_df.set_index("as_of_date")["return"]
+        returns = df.sort_index()["close"].pct_change().dropna()
+        returns.index.name = "as_of_date"
+        return returns
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- compute pct change directly in BaseAnalytics without importing ReturnsCalculator

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_b_6876a80b4cf48325a4a5011449912281